### PR TITLE
Fix broken link in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ Have a look around this site to see what is Project Mu.  Start by reviewing deta
 
 ## Having trouble?
 
-Skim the [FAQ](faq)
+Skim the [FAQ](faq.md)
 
 ## Road map
 


### PR DESCRIPTION
Link to FAQ was not working; required the .md extension.